### PR TITLE
FEATURE: Add sorting ability for TaxonomyTerm children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
-language: php 
+language: php
 
 php: 
  - 5.3
@@ -14,9 +14,9 @@ matrix:
     - php: 5.3
       env: DB=PGSQL CORE_RELEASE=3.1
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=master
+      env: DB=MYSQL CORE_RELEASE=3
     - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=master
+      env: DB=MYSQL CORE_RELEASE=3
 
 before_script:
  - phpenv rehash

--- a/code/TaxonomyAdmin.php
+++ b/code/TaxonomyAdmin.php
@@ -20,4 +20,20 @@ class TaxonomyAdmin extends ModelAdmin {
 		return $list->filter('ParentID', '0');
 	}
 
+	public function getEditForm($id = null, $fields = null) {
+		$form = parent::getEditForm($id, $fields);
+
+		/** @var GridField $gf */
+		$gf = $form->Fields()->dataFieldByName($this->sanitiseClassName($this->modelClass));
+
+		// Setup sorting of TaxonomyTerm siblings, if a suitable module is included
+		if(class_exists('GridFieldOrderableRows')) {
+			$gf->getConfig()->addComponent(new GridFieldOrderableRows('Sort'));
+		} elseif(class_exists('GridFieldSortableRows')) {
+			$gf->getConfig()->addComponent(new GridFieldSortableRows('Sort'));
+		}
+
+		return $form;
+	}
+
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,12 @@
 			"email": "robert@silverstripe.com"
 		}
 	],
-	"require":
-	{
+	"require": {
 		"silverstripe/framework": "~3.1",
 		"silverstripe/cms": "~3.1"
-	}
+	},
+    "suggest": {
+        "silverstripe-australia/gridfieldextensions": "Allows sorting of TaxonomyTerm objects via drag-and-drop",
+        "undefinedoffset/sortablegridfield": "Allows sorting of TaxonomyTerm objects via drag-and-drop"
+    }
 }

--- a/tests/TaxonomyTermTest.php
+++ b/tests/TaxonomyTermTest.php
@@ -28,10 +28,19 @@ class TaxonomyTermTest extends SapphireTest {
 		$vegetable = $this->objFromFixture('TaxonomyTerm', 'Vegetable');
 		$carrot = $this->objFromFixture('TaxonomyTerm', 'Carrot');
 		
-		$this->assertEquals(1, $plant->Children()->Count());
+		$this->assertEquals(2, $plant->Children()->Count());
 		$this->assertEquals($plant->ID, $vegetable->Parent()->ID);
 		$this->assertEquals(1, $vegetable->Children()->Count());
 		$this->assertEquals($vegetable->ID, $carrot->Parent()->ID);
 		$this->assertEquals(0, $carrot->Children()->Count());
+	}
+
+	public function testSorting() {
+		$plant = $this->objFromFixture('TaxonomyTerm', 'Plant');
+		$vegetable = $this->objFromFixture('TaxonomyTerm', 'Vegetable');
+		$fruit = $this->objFromFixture('TaxonomyTerm', 'Fruit');
+
+		$this->assertEquals($fruit->ID, $plant->Children()->first()->ID);
+		$this->assertEquals($vegetable->ID, $plant->Children()->last()->ID);
 	}
 }

--- a/tests/TaxonomyTermTest.yml
+++ b/tests/TaxonomyTermTest.yml
@@ -4,6 +4,11 @@ TaxonomyTerm:
     Vegetable:
         Name: Vegetable
         Parent: =>TaxonomyTerm.Plant
+        Sort: 2
     Carrot:
         Name: Carrot
         Parent: =>TaxonomyTerm.Vegetable
+    Fruit:
+        Name: Fruit
+        Parent: =>TaxonomyTerm.Plant
+        Sort: 1


### PR DESCRIPTION
This allows sorting of TaxonomyTerm objects, by default using a simple NumericField. If either the
gridfieldextensions or sortablegridfield modules are included, then the field is hidden and the GridFields can be
sorted instead.

Added both modules to the suggestions in composer.json, and updated tests to cover a simple sorting case.