### PR TITLE
FEATURE: Add "get or create" functionality to TaxonomyTerm

### DIFF
--- a/code/TaxonomyTerm.php
+++ b/code/TaxonomyTerm.php
@@ -81,6 +81,31 @@ class TaxonomyTerm extends DataObject implements PermissionProvider {
 	public function getTaxonomyName() {
 		return $this->getTaxonomy()->Name;
 	}
+	
+	/**
+	 * Finds a Taxonomy matching the $filter, or if it doesn't find it, it creates a new one.
+	 * If the filter is not specific enough and fetches more than one TaxonomyTerm, it will return the first one
+	 *
+	 * @example $taxonomy = TaxonomyTerm::get_or_create(array('Name'=>'bob'), array('Name'=>'bob', 'ParentID'=>5));
+	 *
+	 * @param array filter to search for
+	 * @param array object to write to the DB if the taxonomy wasn't found
+	 * @return TaxonomyTerm found/created toxonomy
+	 */
+	public static function get_or_create($find, $create) {
+		if(!is_array($find) || !is_array($create)) {
+			throw new InvalidArgumentException('Incorrect arguments passed to TaxonomyTerm::get_or_create()');
+		}
+
+		$taxonomy = TaxonomyTerm::get()->filter($find)->first();
+		if(!$taxonomy || !$taxonomy->exists()) {
+			$taxonomy = new TaxonomyTerm($create);
+			$taxonomy->write();
+		}
+		
+		return $taxonomy;
+	}
+
 
 	public function onBeforeDelete() {
 		parent::onBeforeDelete();

--- a/tests/TaxonomyTermTest.php
+++ b/tests/TaxonomyTermTest.php
@@ -43,4 +43,22 @@ class TaxonomyTermTest extends SapphireTest {
 		$this->assertEquals($fruit->ID, $plant->Children()->first()->ID);
 		$this->assertEquals($vegetable->ID, $plant->Children()->last()->ID);
 	}
+	
+	/**
+	 * Tests correct arguments, get and create a taxonomy
+	 */
+	public function testGetOrCreate() {
+		try {
+			$taxonomy = TaxonomyTerm::get_or_create(1, 'string');
+			$this->fail('An expected exception has not been raised.');
+		} catch (InvalidArgumentException $expected) {}
+		
+		$fruit = TaxonomyTerm::get_or_create(array('Name' => 'Fruit'),
+											 array('Name' => 'Fruit', 'ParentID' => 0));
+		$this->assertEquals($fruit->Sort, 1);
+		
+		$broccoli = TaxonomyTerm::get_or_create(array('Name' => 'Broccoli'),
+												array('Name' => 'Broccoli', 'ParentID' => 0));
+		$this->assertEquals($broccoli->Name, 'Broccoli');
+	}
 }


### PR DESCRIPTION
New static function that tries to find a taxonomy term based on an array, and if it doesn't find it, creates one and returns it.

In a lot of Migration cases I needed this, so I think is better to create a function that adding an extension every time extension to handle that. When using that function you always get a taxonomy term back and you don't have to check if it exists.

Added a simple test for the function, checks all 3 cases (argument error, get an existing TT, create a new one).